### PR TITLE
improve the main layout structure

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Navbar } from './navbar/Navbar';
 export { default as Card } from './card/Card';
+export { default as TableWrapper } from './tableWrapper/TableWrapper';
 export type { IProps } from './types';

--- a/src/components/tableWrapper/TableWrapper.tsx
+++ b/src/components/tableWrapper/TableWrapper.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { IProps } from './../types';
+import './tableWrapper.scss';
+
+/**
+ * Make the THEAD section of the table fixed and provides a scroll through its content.
+ * Also add special styles to the scroll-bar.
+ */
+function TableWrapper({ children, className }: IProps) {
+	return <div className={`table-wrapper ${className}`}>{children}</div>;
+}
+
+export default TableWrapper;

--- a/src/components/tableWrapper/tableWrapper.scss
+++ b/src/components/tableWrapper/tableWrapper.scss
@@ -1,0 +1,20 @@
+.table-wrapper {
+	overflow-y: overlay;
+	border: 1px solid rgba(34, 36, 38, 0.15);
+	border-radius: 0.28571429rem;
+
+	thead {
+		position: sticky;
+		z-index: 1;
+		top: 0;
+	}
+
+	&::-webkit-scrollbar {
+		width: 0.5rem;
+		display: none;
+	}
+
+	&:hover::-webkit-scrollbar {
+		display: block;
+	}
+}

--- a/src/layouts/mainLayout/MainLayout.tsx
+++ b/src/layouts/mainLayout/MainLayout.tsx
@@ -19,7 +19,7 @@ function MainLayout({ children }: IProps) {
 		<div className='main-layout flex-column'>
 			<Provider value={actionsContext}>
 				<Navbar />
-				<div className='flex-1'>{children}</div>
+				<div className='main-layout__content flex-1'>{children}</div>
 			</Provider>
 		</div>
 	);

--- a/src/layouts/mainLayout/mainLayout.scss
+++ b/src/layouts/mainLayout/mainLayout.scss
@@ -2,6 +2,6 @@
 	height: 100%;
 
 	& &__content {
-		padding: 4.5rem 0;
+		overflow-y: overlay;
 	}
 }

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -7,9 +7,10 @@ import { useLoadNavbarContext } from '../../services/hooks';
 import { billingApi } from '../../services/api';
 import { BillStatus, IBill } from '../../domain';
 import './dashboard.scss';
+import { TableWrapper } from '../../components';
 
 function Dashboard() {
-	const [pendingBills, setPendingBills] = useState(true);
+	const [pendingBills, setPendingBills] = useState(false);
 	const [clientId, setClientId] = useState(1);
 	const { bills, setBills } = useGetBillingData(pendingBills, clientId);
 	const billsOrderderPerDate = useMemo(() => {
@@ -60,68 +61,72 @@ function Dashboard() {
 	return (
 		<Container className='dashboard'>
 			<>
-				<h1 className='inline-b'>{pendingBills ? 'Pending Bills' : 'Bill History'}</h1>
-				{pendingBills && (
-					<Input
-						type='number'
-						label='clientId'
-						value={clientId}
-						onChange={(_, data) => setClientId(parseInt(data.value))}
-						min={1}
-						placeholder='Client ID'
-						focus
-						className='dashboard__client-id'
-					/>
-				)}
-				<Table celled padded>
-					<Table.Header>
-						<Table.Row>
-							<Table.HeaderCell singleLine>Client ID</Table.HeaderCell>
-							<Table.HeaderCell>Category</Table.HeaderCell>
-							<Table.HeaderCell>Amount</Table.HeaderCell>
-							<Table.HeaderCell>Status</Table.HeaderCell>
-							<Table.HeaderCell>Updated</Table.HeaderCell>
-							<Table.HeaderCell>Pay</Table.HeaderCell>
-						</Table.Row>
-					</Table.Header>
-
-					<Table.Body>
-						{billsOrderderPerDate.map((bill) => (
+				<div>
+					<h1 className='inline-b'>{pendingBills ? 'Pending Bills' : 'Bill History'}</h1>
+					{pendingBills && (
+						<Input
+							type='number'
+							label='clientId'
+							value={clientId}
+							onChange={(_, data) => setClientId(parseInt(data.value))}
+							min={1}
+							placeholder='Client ID'
+							focus
+							className='dashboard__client-id'
+						/>
+					)}
+				</div>
+				<TableWrapper className='flex-1'>
+					<Table celled padded>
+						<Table.Header>
 							<Table.Row>
-								<Table.Cell>
-									<Header as='h4' textAlign='center'>
-										{bill.clientId}
-									</Header>
-								</Table.Cell>
-								<Table.Cell singleLine>
-									<Header as='h4'>{bill.category}</Header>
-								</Table.Cell>
-								<Table.Cell textAlign='right'>
-									<Header as='h4'>{bill.amount}</Header>
-								</Table.Cell>
-								<Table.Cell textAlign='right'>
-									<Header as='h4' textAlign='center'>
-										{bill.status}
-									</Header>
-								</Table.Cell>
-								<Table.Cell textAlign='right'>
-									<Header as='h4'>{moment(bill.updated).format('dddd, MMMM Do YYYY')}</Header>
-								</Table.Cell>
-								<Table.Cell className='justify-content-c'>
-									<PayModal
-										bill={bill}
-										updateBills={updateBills}
-										trigger={
-											<Button positive disabled={bill.status !== 'PENDING'}>
-												<Icon name='money bill alternate outline' /> Pay
-											</Button>
-										}
-									/>
-								</Table.Cell>
+								<Table.HeaderCell singleLine>Client ID</Table.HeaderCell>
+								<Table.HeaderCell>Category</Table.HeaderCell>
+								<Table.HeaderCell>Amount</Table.HeaderCell>
+								<Table.HeaderCell>Status</Table.HeaderCell>
+								<Table.HeaderCell>Updated</Table.HeaderCell>
+								<Table.HeaderCell>Pay</Table.HeaderCell>
 							</Table.Row>
-						))}
-					</Table.Body>
-				</Table>
+						</Table.Header>
+
+						<Table.Body>
+							{billsOrderderPerDate.map((bill) => (
+								<Table.Row>
+									<Table.Cell>
+										<Header as='h4' textAlign='center'>
+											{bill.clientId}
+										</Header>
+									</Table.Cell>
+									<Table.Cell singleLine>
+										<Header as='h4'>{bill.category}</Header>
+									</Table.Cell>
+									<Table.Cell textAlign='right'>
+										<Header as='h4'>{bill.amount}</Header>
+									</Table.Cell>
+									<Table.Cell textAlign='right'>
+										<Header as='h4' textAlign='center'>
+											{bill.status}
+										</Header>
+									</Table.Cell>
+									<Table.Cell textAlign='right'>
+										<Header as='h4'>{moment(bill.updated).format('dddd, MMMM Do YYYY')}</Header>
+									</Table.Cell>
+									<Table.Cell className='justify-content-c'>
+										<PayModal
+											bill={bill}
+											updateBills={updateBills}
+											trigger={
+												<Button positive disabled={bill.status !== 'PENDING'}>
+													<Icon name='money bill alternate outline' /> Pay
+												</Button>
+											}
+										/>
+									</Table.Cell>
+								</Table.Row>
+							))}
+						</Table.Body>
+					</Table>
+				</TableWrapper>
 			</>
 		</Container>
 	);

--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -2,6 +2,8 @@
 	background-color: transparent;
 	padding: 3rem 0;
 	height: 100%;
+	display: flex !important;
+	flex-direction: column;
 
 	& &__client-id {
 		margin-left: 2rem;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -75,3 +75,11 @@ LAYOUT
 .v-hidden {
 	visibility: hidden;
 }
+
+// overflow
+.overflow-h {
+	overflow: hidden;
+}
+.overflow-a {
+	overflow: auto;
+}


### PR DESCRIPTION
Currently there was a problem where the table coudln't be set the scrollbar for
its body and the approach that was taken was:
- improve the flex layout of the main layout by setting appropriate overflow properties.
- wrap the table component for applying scroll properties without modifying the display
properties of the table and its children.